### PR TITLE
Fixed the Maria db configuration for arm32v7 devices

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloud:20.0.3-fpm-alpine
+FROM nextcloud:19.0.10-fpm-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache sudo

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.5.5
+FROM yobasystems/alpine-mariadb
 
 COPY my.cnf /etc/mysql/my.cnf
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - app
 
   # https://hub.docker.com/_/mariadb/
+  # https://hub.docker.com/r/yobasystems/alpine-mariadb/
   db:
     build: db
     volumes:
@@ -54,6 +55,7 @@ services:
       MYSQL_PASSWORD: nextcloud
 
   # https://hub.docker.com/_/mariadb/
+  # https://hub.docker.com/r/yobasystems/alpine-mariadb/
   sqldump:
     build: db
     command: "/sqldump.sh"


### PR DESCRIPTION
Maria DB didn't have an arm32v7 version; this was causing the build to fail. I have updated the DB/Dockerfile to the version that supports arm32v7.